### PR TITLE
Add a getName() function for GT machines connected via an adapter to retrieve their entity name.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.11'
     }
 }
 

--- a/src/main/java/pl/asie/computronics/integration/gregtech/gregtech5/DriverMachine.java
+++ b/src/main/java/pl/asie/computronics/integration/gregtech/gregtech5/DriverMachine.java
@@ -68,6 +68,15 @@ public class DriverMachine extends DriverSidedTileEntity {
 		    else
                 return new Object[] {};
         }
+
+        @Callback(doc = "function():string; Returns the machine's name", direct = true)
+        public Object[] getName(Context c, Arguments a) {
+            return new Object[] {
+                tile.getIGregTechTileEntity(tile.getXCoord(), tile.getYCoord(), tile.getZCoord())
+                .getMetaTileEntity()
+                .getMetaName()
+            };
+        }
 	}
 
 	@Override


### PR DESCRIPTION
See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11885 .