### PR TITLE
Stop OC from executing getInfoData in its worker thread

### DIFF
--- a/src/main/java/pl/asie/computronics/integration/gregtech/gregtech5/DriverDeviceInformation.java
+++ b/src/main/java/pl/asie/computronics/integration/gregtech/gregtech5/DriverDeviceInformation.java
@@ -20,7 +20,7 @@ public class DriverDeviceInformation extends DriverSidedTileEntity {
             super(tile, name);
         }
 
-        @Callback(doc = "function():table; Returns sensor information about this block", direct = true)
+        @Callback(doc = "function():table; Returns sensor information about this block", direct = false)
         public Object[] getSensorInformation(Context c, Arguments a) {
             return new Object[] { tile.getInfoData() };
         }


### PR DESCRIPTION
 This should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13528 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13527
 
 This means that people using this API will need to wait up to one tick for it to return. The alternative, it seems, is checking every implementation of _getInfoData_ for any race conditions.
 
 This was mentioned in the context of NIDAS, and I don't really know much about OC. @S4mpsa will this cause anything to explode (literally or otherwise) on your end?