### PR TITLE
Change recipes to remove quadruple plate usage

### DIFF
--- a/src/main/java/pl/asie/computronics/integration/gregtech/gregtech6/GregTech6Recipes.java
+++ b/src/main/java/pl/asie/computronics/integration/gregtech/gregtech6/GregTech6Recipes.java
@@ -602,7 +602,7 @@ public class GregTech6Recipes extends ModRecipes {
                 't',
                 new ItemStack(Computronics.itemPartsGreg, 1, 0),
                 'p',
-                "plateQuadrupleTungstenSteel",
+                "plateTripleTungstenSteel",
                 'c',
                 IL.Processor_Crystal_Sapphire.get(1));
 


### PR DESCRIPTION
Related: https://github.com/GTNewHorizons/GT5-Unofficial/pull/3821