### PR TITLE
Remove version pin on MC1710 for GT5

### DIFF
--- a/src/main/java/pl/asie/computronics/Computronics.java
+++ b/src/main/java/pl/asie/computronics/Computronics.java
@@ -395,7 +395,8 @@ public class Computronics {
     @EventHandler
     public void postInit(FMLPostInitializationEvent event) {
 
-        if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech5) && Config.GREGTECH_RECIPES) {
+        if (Mods.isLoaded(Mods.GregTech) && !Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6)
+                && Config.GREGTECH_RECIPES) {
             ModRecipes.instance = new GregTech5Recipes();
         } else if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6) && Config.GREGTECH_RECIPES) {
             ModRecipes.instance = new GregTech6Recipes();
@@ -410,7 +411,7 @@ public class Computronics {
 
         // Mod compat - GregTech
         if (itemTape != null && itemPartsGreg != null) {
-            if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech5)) {
+            if (Mods.isLoaded(Mods.GregTech) && !Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6)) {
                 GregTech5Recipes.registerStandardGregTechRecipes();
             } else if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6)) {
                 GregTech6Recipes.registerStandardGregTechRecipes();

--- a/src/main/java/pl/asie/computronics/oc/IntegrationOpenComputers.java
+++ b/src/main/java/pl/asie/computronics/oc/IntegrationOpenComputers.java
@@ -263,7 +263,7 @@ public class IntegrationOpenComputers {
                 Driver.add(new DriverPrimingTrack.OCDriver());
             }
         }
-        if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech5)) {
+        if (Mods.isLoaded(Mods.GregTech) && !Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6)) {
             if (compat.isCompatEnabled(Compat.GregTech_Machines)) {
                 Driver.add(new DriverBaseMetaTileEntity());
                 Driver.add(new DriverDeviceInformation());

--- a/src/main/java/pl/asie/computronics/reference/Mods.java
+++ b/src/main/java/pl/asie/computronics/reference/Mods.java
@@ -6,7 +6,7 @@ import cpw.mods.fml.common.versioning.ArtifactVersion;
 
 /**
  * List of used mod IDs
- * 
+ *
  * @author Vexatos
  */
 public class Mods {
@@ -44,7 +44,7 @@ public class Mods {
     public static class Versions {
 
         public static final String BuildCraftTiles = "[1.1,)", Forestry = "[4.2.0,)", Gendustry = "[2.0.0,)",
-                GregTech5 = "[MC1710]", GregTech6 = "[GT6-MC1710]";
+                GregTech6 = "[GT6-MC1710]";
     }
 
     public static boolean isLoaded(String name) {

--- a/src/main/java/pl/asie/computronics/util/achievements/ComputronicsAchievements.java
+++ b/src/main/java/pl/asie/computronics/util/achievements/ComputronicsAchievements.java
@@ -88,7 +88,7 @@ public class ComputronicsAchievements {
                     false,
                     false);
 
-            if (Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech5)) {
+            if (Mods.isLoaded(Mods.GregTech) && !Mods.hasVersion(Mods.GregTech, Mods.Versions.GregTech6)) {
                 this.registerAchievement(
                         EnumAchievements.Tape_IG,
                         8,


### PR DESCRIPTION
This PR removes the version pin to MC1710 for GT5 and replaces all usages that were checking directly against the version for compat between GT6 & 5 with just check if GT6 and assumes GT5 otherwise.

As caused by https://github.com/GTNewHorizons/GT5-Unofficial/pull/6741